### PR TITLE
Add optional time_source param to pass to CronParser

### DIFF
--- a/lib/em/cron.rb
+++ b/lib/em/cron.rb
@@ -5,6 +5,7 @@ require "em/cron/version"
 module EM
   class Cron
     # @param cron_string [String]
+    # @param time_source [Class]
     # @yield [Time] the time the block was scheduled to be called by cron. If
     #   yielding this block returns `:stop` then the schedule stops.
     # @example
@@ -13,10 +14,10 @@ module EM
     #       puts "hello world at time: #{time}"
     #     end
     #   end
-    def self.schedule(cron_string, &blk)
-      cron_parser = CronParser.new(cron_string)
-      next_time = cron_parser.next(Time.now)
-      EM.add_timer(next_time - Time.now) do
+    def self.schedule(cron_string, time_source = Time, &blk)
+      cron_parser = CronParser.new(cron_string, time_source)
+      next_time = cron_parser.next(time_source.now)
+      EM.add_timer(next_time - time_source.now) do
         result = yield(next_time)
         schedule(cron_string, &blk) unless result == :stop
       end


### PR DESCRIPTION
Hey @dgvz! Thanks for making `em-cron`. 😄 

I have a use case where I want a task to be scheduled for particular hours of the day, and timezones make this complicated (since system times are often UTC, but we want these tasks to occur at particular hours in our local time).

I noticed `CronParser` [allows you to pass an extra parameter](https://github.com/siebertm/parse-cron/blob/5ff2cd5bb6c469bf5aa499a90fa49bdc19fcd94b/lib/cron_parser.rb#L12) - `time_source`. For example, `Time.zone` from ActiveSupport could be passed in and `CronParser` will use `time_source` for its time calculations - effectively making `em-cron` work with timezones, for people who need that.

Behavior remains the same for existing users since it falls back on `Time`.
